### PR TITLE
fix: num_chomped on FastReal impl

### DIFF
--- a/lib/github.com/shwestrick/sml-fast-real/FastReal.sml
+++ b/lib/github.com/shwestrick/sml-fast-real/FastReal.sml
@@ -219,26 +219,28 @@ struct
           (false, 0, exponent, i)
         else
           let
-            val i = i + 1
-
-            val (explicit_exponent_is_negative, i) =
-              if get i = #"-" orelse get i = #"~" then (true, i + 1)
-              else if get i = #"+" then (false, i + 1)
-              else (false, i)
-
-            val (explicit_exponent_num, i') =
-              push_digit_chars 0w0 {start = i, stop = stop, get = get}
-            val explicit_exponent_digit_count = i' - i
-            val i = i'
-
-            val explicit_exponent_num = Word64.toIntX explicit_exponent_num
-            val explicit_exponent_num =
-              if explicit_exponent_is_negative then ~explicit_exponent_num
-              else explicit_exponent_num
-
-            val exponent = exponent + explicit_exponent_num
+            val i_after_e = i + 1
+            val (explicit_exponent_is_negative, i_after_sign) =
+              if i_after_e >= stop then (false, i_after_e)
+              else if get i_after_e = #"-" orelse get i_after_e = #"~" then (true, i_after_e + 1)
+              else if get i_after_e = #"+" then (false, i_after_e + 1)
+              else (false, i_after_e)
+            val (explicit_exponent_num, i_after_digits) =
+              push_digit_chars 0w0 {start = i_after_sign, stop = stop, get = get}
+            val explicit_exponent_digit_count = i_after_digits - i_after_sign
           in
-            (true, explicit_exponent_digit_count, exponent, i)
+            if explicit_exponent_digit_count = 0 then
+              (false, 0, exponent, i)
+            else
+              let
+                val explicit_exponent_num = Word64.toIntX explicit_exponent_num
+                val explicit_exponent_num =
+                  if explicit_exponent_is_negative then ~explicit_exponent_num
+                  else explicit_exponent_num
+                val exponent = exponent + explicit_exponent_num
+              in
+                (true, explicit_exponent_digit_count, exponent, i_after_digits)
+              end
           end
 
     (* val _ = print ("start " ^ itos start ^ "\n")

--- a/test/test.sml
+++ b/test/test.sml
@@ -162,3 +162,12 @@ val (rs_from_chars, num_fast) = Benchmark.run "from_chars" (fn () =>
 
 val _ = print ("NUM FAST " ^ Int.toString num_fast ^ "\n")
 val () = report_errors rs_from_chars
+
+(* val () = print "SANITY CHECK: 123.456e+\n";
+val test_str = "123.456e+"
+fun reader i = if i >= String.size test_str then NONE else SOME (String.sub (test_str, i), i + 1)
+val (r, stop) = valOf (Real.scan reader 0)
+val _ = print ("Real.scan num_chomped: " ^ Int.toString stop ^ "\n")
+val {num_chomped, ...} = valOf (FR.from_chars_with_info 
+  {start = 0, stop = String.size test_str, get = fn i => String.sub (test_str, i)})
+val _ = print ("FastReal num_chomped: " ^ Int.toString num_chomped ^ "\n") *)


### PR DESCRIPTION
- added a quick fix that backtracks when explicit_exponent_digit_count is zero
- seems to work on the "123.456e+" test case
- will do some more thorough testing soon 🙂
- the problematic test case from earlier is commented out in `test.sml` -> will move it into a separate file